### PR TITLE
Add validation to required fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "font-awesome-rails"
 gem "flutie"
 gem "high_voltage"
 gem "geocoder"
+gem 'rails-i18n', '~> 4.0.0'
 gem "i18n-tasks"
 gem "jquery-rails"
 gem "neat", "~> 1.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails-i18n (4.0.5)
+      i18n (~> 0.6)
+      railties (~> 4.0)
     railties (4.2.1)
       actionpack (= 4.2.1)
       activesupport (= 4.2.1)
@@ -295,6 +298,7 @@ DEPENDENCIES
   rack-canonical-host
   rack-timeout
   rails (= 4.2.1)
+  rails-i18n (~> 4.0.0)
   recipient_interceptor
   refills
   rspec-rails (~> 3.1.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,10 @@
   background-color: $medium-gray;
 }
 
+.field_with_errors .error {
+  color: $red;
+ }
+
 .share-area {
   @include flash($success-color);
   border-radius: 3px;

--- a/app/controllers/insamlings_controller.rb
+++ b/app/controllers/insamlings_controller.rb
@@ -10,12 +10,14 @@ class InsamlingsController < ApplicationController
   end
 
   def create
-    insamling = Insamling.new(insamlings_params)
+    @insamling = Insamling.new(insamlings_params)
 
-    if insamling.save
-      InsamlingMailer.send_confirmation_email(insamling).deliver_now
+    if @insamling.save
+      InsamlingMailer.send_confirmation_email(@insamling).deliver_now
       flash[:notice] = "Insamlingen skapades. Kolla din mail för inloggningsuppgifter"
-      redirect_to insamling_url(insamling)
+      redirect_to insamling_url(@insamling)
+    else
+      render :new
     end
   end
 

--- a/app/models/insamling.rb
+++ b/app/models/insamling.rb
@@ -1,9 +1,11 @@
 class Insamling < ActiveRecord::Base
   has_many :needs
+  validates_presence_of [:about, :user_email]
+  validates_format_of :user_email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create
 
   before_create :generate_admin_token
   geocoded_by :location
-  after_validation :geocode
+  after_validation :geocode, if: ->(obj){ location.present? and location_changed? }
 
   private
 

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,1 @@
+I18n.default_locale = :sv

--- a/spec/controllers/insamlings_controller_spec.rb
+++ b/spec/controllers/insamlings_controller_spec.rb
@@ -120,6 +120,21 @@ describe InsamlingsController do
       expect(mail.from.first).to eql("info@insamlingslistan.se")
       expect(mail.to.first).to eql("good@person.com")
     end
+
+    context "with invalid parameters" do
+      it "renders the 'new' template" do
+        params = {
+          insamling: {
+            user_email: "bademail",
+          }
+        }
+
+        post :create, params
+
+        expect(response).to render_template(:new)
+        expect(assigns(:insamling)).to be_a(Insamling)
+      end
+    end
   end
 
   def stub_geocoding

--- a/spec/features/create_new_list_spec.rb
+++ b/spec/features/create_new_list_spec.rb
@@ -30,6 +30,15 @@ feature "Creating a new list" do
     expect_number_of_needs_to_be 1
   end
 
+  scenario "without required data shows validation errors" do
+    visit "/"
+    click_link "Skapa en lista"
+
+    click_button "Skapa lista"
+
+    expect(number_of_errors).to be 2
+  end
+
   def user_clicks_admin_link_in_email
     visit "/insamlings/#{ @insamling.id }/admins/#{ @insamling.admin_token }"
   end
@@ -50,6 +59,10 @@ feature "Creating a new list" do
   def remove_need(index)
     need_element = all(".needs li")[index]
     need_element.click_link("Ta bort")
+  end
+
+  def number_of_errors
+    all(".field_with_errors .error").length
   end
 
   def expect_number_of_needs_to_be(expected_number_of_needs)

--- a/spec/models/insamling_spec.rb
+++ b/spec/models/insamling_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe Insamling do
+  before(:all) do 
+    stub_geocoding
+  end
+
+  it { should validate_presence_of(:about) }
+  it { should validate_presence_of(:user_email) }
+
+  describe "with invalid email" do
+    it "rejects email without domain" do
+      expect_email_to_fail_validation "this@is"
+    end
+
+    it "rejects email without @" do
+      expect_email_to_fail_validation "this.is.com"
+    end
+
+    it "rejects email without anything before @" do
+      expect_email_to_fail_validation "@is.com"
+    end
+
+    def expect_email_to_fail_validation(email)
+      insamling = build(:insamling, user_email: email)
+
+      expect(insamling.valid?).to be false
+    end
+  end
+
+  def stub_geocoding
+    Geocoder.configure(:lookup => :test)
+
+    Geocoder::Lookup::Test.set_default_stub([
+      {
+        'latitude'     => 40.7143528,
+        'longitude'    => -74.0059731,
+        'address'      => 'gatan 1',
+        'country'      => 'stan',
+        'country_code' => 'SE'
+      }
+     ]
+    )
+  end
+end


### PR DESCRIPTION
- Use swedish translation for the validation errors (as well as the
  entire app)
- Validate that user_email matches an email pattern
- user_email and about are now required
